### PR TITLE
Remove duplicated team section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -53,10 +53,6 @@
   {{ partial "team.html" . }}
   {{ end }}
 
-  {{ if .Site.Params.team.enable }}
-  {{ partial "team.html" . }}
-  {{ end }}
-
   {{ if .Site.Params.diversity.enable }}
   {{ partial "diversity.html" . }}
   {{ end }}


### PR DESCRIPTION
I noticed that the team section is currently displayed twice when it is enabled