### PR TITLE
Add Eventbrite registration section to navbar

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -35,6 +35,12 @@
           </li>
         {{ end }}
 
+        {{ if .Site.Params.eventbrite.enable }}
+          <li>
+            <a class="page-scroll" href="{{ .Site.BaseURL }}#eventbrite">{{ with .Site.Params.navigation.eventbrite }}{{ . }}{{ end }}</a>
+          </li>
+        {{ end }}
+
         {{ if .Site.Params.services.enable }}
           <li>
             <a class="page-scroll" href="{{ .Site.BaseURL }}#services">{{ with .Site.Params.navigation.services }}{{ . }}{{ end }}</a>


### PR DESCRIPTION
@DaveParr When I enabled the Eventbrite registration section, it wasn't added to the navbar. This PR restores this behavior.