### PR TITLE
generalise the registration link in navbar solution from @jdblischack to work across all ticket providers

### DIFF
--- a/layouts/partials/eventbrite.html
+++ b/layouts/partials/eventbrite.html
@@ -1,5 +1,5 @@
 {{ "<!-- eventbrite -->" | safeHTML }}
-<section id="eventbrite" {{ if .Site.Params.eventbrite.bg }}
+<section id="registration" {{ if .Site.Params.eventbrite.bg }}
 class="bg-light-gray"
 {{ end }}>
   <div class="container">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -35,12 +35,6 @@
           </li>
         {{ end }}
 
-        {{ if .Site.Params.eventbrite.enable }}
-          <li>
-            <a class="page-scroll" href="{{ .Site.BaseURL }}#eventbrite">{{ with .Site.Params.navigation.eventbrite }}{{ . }}{{ end }}</a>
-          </li>
-        {{ end }}
-
         {{ if .Site.Params.services.enable }}
           <li>
             <a class="page-scroll" href="{{ .Site.BaseURL }}#services">{{ with .Site.Params.navigation.services }}{{ . }}{{ end }}</a>
@@ -49,7 +43,7 @@
 
         {{ if or (.Site.Params.eventbrite.enable) (.Site.Params.tickettailor.enable) (.Site.Params.tito.enable)}}
           <li>
-            <a class="page-scroll" href="{{ .Site.BaseURL }}#registration">{{ with .Site.Params.navigation.eventbrite }}{{ . }}{{ end }}</a>
+            <a class="page-scroll" href="{{ .Site.BaseURL }}#registration">Registration</a>
           </li>
         {{ end }}
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -47,6 +47,12 @@
           </li>
         {{ end }}
 
+        {{ if or (.Site.Params.eventbrite.enable) (.Site.Params.tickettailor.enable) (.Site.Params.tito.enable)}}
+          <li>
+            <a class="page-scroll" href="{{ .Site.BaseURL }}#registration">{{ with .Site.Params.navigation.eventbrite }}{{ . }}{{ end }}</a>
+          </li>
+        {{ end }}
+
         {{ if .Site.Params.portfolio.enable }}
           <li>
             <a class="page-scroll" href="{{ .Site.BaseURL }}#portfolio">{{ with .Site.Params.navigation.portfolio }}{{ . }}{{ end }}</a>

--- a/layouts/partials/tickettailor.html
+++ b/layouts/partials/tickettailor.html
@@ -1,5 +1,5 @@
 {{ "<!-- tickettailor -->" | safeHTML }}
-<section id="tickettailor" {{ if .Site.Params.tickettailor.bg }}
+<section id="registration" {{ if .Site.Params.tickettailor.bg }}
 class="bg-light-gray"
 {{ end }}>
   <div class="container">

--- a/layouts/partials/tito.html
+++ b/layouts/partials/tito.html
@@ -1,5 +1,5 @@
 {{ "<!-- tito -->" | safeHTML }}
-<section id="tito" {{ if .Site.Params.tito.bg }}
+<section id="registration" {{ if .Site.Params.tito.bg }}
 class="bg-light-gray"
 {{ end }}>
   <div class="container">


### PR DESCRIPTION
in #45 @jdblischak proposed a solution to generalise based on modifying the section ID.

> Another idea: change the template files for the registration providers so that they all use `id="registration"`. Then the navbar link could be shared between them, i.e. `href="{{ .Site.BaseURL }}#registration">`. I think in the edge case of the template where multiple registration vendors are enabled, the link would take you to the first div with a matching id.

I've implemented this along with an OR statement in the nav bar to tirgger the link being available or not.