### PR TITLE
Remove leftover paper.js reference in the footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,6 +30,4 @@
 
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
   <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <script type="text/paperscript" src="js/trianglewave.js" canvas="Trianglewave" async></script>
-  <script type="text/javascript" src="js/paper-full.min.js" async></script>
     


### PR DESCRIPTION
Because of #51 we no longer need the reference to those files in the footer partial